### PR TITLE
`antdStrings` defined in the facade

### DIFF
--- a/facades/antd-slinky/src/main/scala/typings/antdLib/AntdFacade.scala
+++ b/facades/antd-slinky/src/main/scala/typings/antdLib/AntdFacade.scala
@@ -136,6 +136,8 @@ object AntdFacade extends antdLibProps {
   @inline def NotificationArgsProps = typings.antdLib.esNotificationMod.ArgsProps
   type NotificationArgsProps = typings.antdLib.esNotificationMod.ArgsProps
 
+  val antdStrings: typings.antdLib.antdLibStrings.type = typings.antdLib.antdLibStrings
+  
   /**
    * This is an example of something a bit more complicated than just rewriting component types, and which a manually
    *  written facade. Given an implementation of a component which has a `form` prop which is to be prefilled,


### PR DESCRIPTION
Note: I went for a longer `antdStrings` instead of `Strings`, worrying about the possibility of projects using more than one facade written in this style.