### PR TITLE
Fix the type of lines

### DIFF
--- a/l/lyric-parser/src/main/scala/typings/lyricParser/mod.scala
+++ b/l/lyric-parser/src/main/scala/typings/lyricParser/mod.scala
@@ -10,7 +10,7 @@ object mod extends js.Object {
   @js.native
   trait Lyric extends js.Object {
     var curLine: Double = js.native
-    var lines: js.Array[String] = js.native
+    var lines: js.Array[AnonLineNum] = js.native
     var lrc: String = js.native
     var state: Double = js.native
     var tags: AnonAlbum = js.native


### PR DESCRIPTION
The inner type should be js.Array[AnonLineNum] instead of js.Array[String]